### PR TITLE
Use a separate index from the polaris.shopify.com website

### DIFF
--- a/resources/assets/javascript/algoliaSearch.js
+++ b/resources/assets/javascript/algoliaSearch.js
@@ -4,7 +4,7 @@ const index = initialize();
 
 function initialize() {
   const client = algoliasearch('VPPOBYF1PX', '7b5cb1cfd32091ade772492262a88989');
-  return client.initIndex('polaris');
+  return client.initIndex('telescope');
 }
 
 export default function algoliaSearch(query) {


### PR DESCRIPTION
At the moment, polaris-telescope requests made to the polaris search index pollutes analytics in a way that prevents us from knowing what's a website request from a telescope request. Switching the Sketch plugin to use its own index solves the issue.