### PR TITLE
Updates plugin version on Webview

### DIFF
--- a/resources/webview.html
+++ b/resources/webview.html
@@ -15,7 +15,7 @@
           'appName': 'marketing-misc',
           'defaultAttributes': {
             'plugin-identifier': 'polaris-telescope',
-            'polarisInSketchVersion': '0.9.0'
+            'polarisInSketchVersion': '0.9.2'
           }
         },
         'Clickstream': {}


### PR DESCRIPTION
A new version of Polaris Telescope was released but the Trekkie configuration on the Webview was not updated with the new version. This is preventing us from tracking the distribution of the plugin properly. 

This PR updates the plugin's version used by Trekkie.