### PR TITLE
Deprecate polaris-telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Deprecated: as of July 2019, this project is no longer maintained, meaning it may not work in future versions of Sketch.
+
+---
+
 ![cover image](https://user-images.githubusercontent.com/8864990/34141733-30476ca2-e451-11e7-92ab-a779e31d6a34.png)
 
 # Polaris Telescope


### PR DESCRIPTION
Note to self: also mention this deprecation in https://github.com/Shopify/polaris-styleguide/edit/master/pages/resources/polaris-telescope.md